### PR TITLE
Add types exports to the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,14 @@
   "module": "./dist/esm/index.js",
   "exports": {
     ".": {
-      "require": "./dist/cjs/index.js",
-      "default": "./dist/esm/index.js"
+      "require": {
+        "types": "./dist/cjs/declarations/index.d.ts",
+        "default": "./dist/cjs/index.js"
+      },
+      "default": {
+        "types": "./dist/esm/declarations/index.d.ts",
+        "default": "./dist/esm/index.js"
+      }
     }
   },
   "sideEffects": false,


### PR DESCRIPTION
The new TypeScript moduleResolutions `node16/nodenext/bundler` require types declarations for packages that have `exports`.
This resolves the error `TS7016: Could not find a declaration file for module 'mantine-flagpack'. '/node_modules/mantine-flagpack/dist/esm/index.js' implicitly has an 'any' type.   There are types at '/node_modules/mantine-flagpack/declarations/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'mantine-flagpack' library may need to update its package.json or typings.`
Reference: https://github.com/microsoft/TypeScript/issues/52363
